### PR TITLE
Removal of * and more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,24 +104,6 @@ julia> setindex(a, 1.337, 2)
 
 ## Operations
 
-### Scaling
-The symbol `*` can be used for multiplication between a number and a tensor, i.e. scaling of the tensor `A` with scalar `a`.
-
-```jl
-julia> a = 2.0;
-
-julia> A = rand(SymmetricTensor{2,2})
-2x2 ContMechTensors.SymmetricTensor{2,2,Float64,3}:
- 0.151352    0.00806314
- 0.00806314  0.287282
-
-julia> a*A
-2x2 ContMechTensors.SymmetricTensor{2,2,Float64,3}:
- 0.302704   0.0161263
- 0.0161263  0.574564
-```
-
-
 ### Single contraction (dot product)
 
 Single contractions or scalar products of a tensor with order `n` and a tensor with order `m` gives a tensor with order `m + n - 2`. The symbol `⋅`, written `\cdot`, is overloaded for single contraction.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ julia> B[1, 2, 1, 2]
 
 In order to set an index the function `setindex(t, value, index...)` is used. This returns a new tensor with the modified index. Explicitly setting indicies is not recommended in performance critical code since it will invoke dynamic dispatch. It is provided as a means of convenience when working in for example the REPL.
 
-```julia
+```jl
 julia> a = rand(Vec{2});
 
 julia> setindex(a, 1.337, 2)
@@ -104,11 +104,54 @@ julia> setindex(a, 1.337, 2)
 
 ## Operations
 
-The symbol `*` is overloaded for double contractions between fourth and second order tensors, and single contractions between two second order tensors or between a second and first order tensor.
+### Scaling
+The symbol `*` can be used for multiplication between a number and a tensor, i.e. scaling of the tensor `A` with scalar `a`.
 
-### Double contractions
+```jl
+julia> a = 2.0;
 
-Double contractions contracts the two most inner "legs" of the tensors. The result of a double contraction between a tensor of order `n` and a tensor with order `m` gives a tensor with order `m + n - 4`. The symbol `⊡`, written `\boxdot` is overloaded for double contraction. The reason `:` is not used is because it does not have the same precedence as multiplication.
+julia> A = rand(SymmetricTensor{2,2})
+2x2 ContMechTensors.SymmetricTensor{2,2,Float64,3}:
+ 0.151352    0.00806314
+ 0.00806314  0.287282
+
+julia> a*A
+2x2 ContMechTensors.SymmetricTensor{2,2,Float64,3}:
+ 0.302704   0.0161263
+ 0.0161263  0.574564
+```
+
+
+### Single contraction (dot product)
+
+Single contractions or scalar products of a tensor with order `n` and a tensor with order `m` gives a tensor with order `m + n - 2`. The symbol `⋅`, written `\cdot`, is overloaded for single contraction.
+
+```jl
+julia> A = rand(Tensor{2, 2})
+2x2 ContMechTensors.Tensor{2,2,Float64,4}:
+ 0.0928652  0.664058
+ 0.799669   0.979861
+
+julia> B = rand(Tensor{1, 2})
+2-element ContMechTensors.Tensor{1,2,Float64,2}:
+ 0.687288
+ 0.461646
+
+julia> dot(A, B)
+2-element ContMechTensors.Tensor{1,2,Float64,2}:
+ 0.370385
+ 1.00195 
+
+julia> A ⋅ B
+2-element ContMechTensors.Tensor{1,2,Float64,2}:
+ 0.370385
+ 1.00195
+```
+
+
+### Double contraction
+
+Double contractions contracts the two most inner "legs" of the tensors. The result of a double contraction between a tensor of order `n` and a tensor with order `m` gives a tensor with order `m + n - 4`. The symbol `⊡`, written `\boxdot`, is overloaded for double contraction. The reason `:` is not used is because it does not have the same precedence as multiplication.
 
 ```jl
 julia> A = rand(SymmetricTensor{2, 2});
@@ -122,30 +165,10 @@ julia> A ⊡ B
 0.9392510193487607
 ```
 
-### Single contraction (dot products)
 
-Single contractions or scalar products of a tensor with order `n` and a tensor with order `m` gives a tensor with order `m + n - 2`. The symbol `⋅` is overloaded for single contractiom.
+### Tensor product (open product)
 
-```jl
-julia> A = rand(Tensor{2, 2})
-2x2 ContMechTensors.Tensor{2,2,Float64,1}:
- 0.246704  0.379757
- 0.180964  0.947665
-
-julia> B = rand(Tensor{1, 2})
-2-element ContMechTensors.Tensor{1,2,Float64,1}:
- 0.772635
- 0.0625623
-
-julia> dot(A, B)
-2-element ContMechTensors.Tensor{1,2,Float64,1}:
- 0.214371
- 0.199108
-```
-
-### Tensor products
-
-Tensor products or open products of a tensor with order `n` and a tensor with order `m` gives a tensor with order `m + n`T. he symbol `⊗` is overloaded for tensor products.
+Tensor products or open product of a tensor with order `n` and a tensor with order `m` gives a tensor with order `m + n`. The symbol `⊗`, written `\otimes`, is overloaded for tensor products.
 
 ```jl
 julia> A = rand(SymmetricTensor{2, 2});
@@ -179,7 +202,7 @@ There is also a special function for computing `F' ⋅ F` between two general se
 
 Even though a user mostly deals with the `Tensor{order, dim, T}` parameters, the full parameter list for a tensor is actually `Tensor{order, dim, T, N}` where `N` is the number of independent elements in the tensor. The reason for this is that the internal storage is a `NTuple{N, T}`. In order to get good performance when storing tensors in other types it is importatant that the container type is also parametrized on `N`. For example, when storing one symmetric second order tensor and one unsymmetric tensor, this is the preferred way:
 
-```julia
+```jl
 immutable Container{dim, T, N, M}
     sym_tens::SymmetricTensor{2, dim, T, N}
     tens::Tensor{2, dim, T, M}

--- a/src/symmetric_ops.jl
+++ b/src/symmetric_ops.jl
@@ -127,9 +127,6 @@ end
 end
 @inline Base.dot{dim, T}(v2::Vec{dim, T}, S1::SymmetricTensor{2, dim, T}) = dot(S1, v2)
 
-@inline Base.(:*){dim, T}(S1::SymmetricTensor{2, dim, T}, v1::Vec{dim, T}) = dot(S1, v1)
-@inline Base.(:*){dim, T}(v1::Vec{dim, T}, S1::SymmetricTensor{2, dim, T}) = dot(v1, S1)
-
 
 ###########
 # Inverse #

--- a/src/tensor_ops.jl
+++ b/src/tensor_ops.jl
@@ -1,7 +1,14 @@
-# Deprecate `*` for single/double contraction
+# Stop `*` from working with tensors
 function Base.(:*)(S1::AbstractTensor, S2::AbstractTensor)
     error("Don't use `*` for multiplication between tensors. Use `⋅` (`\\cdot`) for single contraction and `⊡` (`\\boxdot`) for double contraction.")
 end
+function Base.Ac_mul_B{dim}(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim})
+    error("Don't use `A'*B`, use `tdot(A,B)` (or `A'⋅B`) instead.")
+end
+function Base.At_mul_B{dim}(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim})
+    error("Don't use `A.'*B`, use `tdot(A,B)` (or `A.'⋅B`) instead.")
+end
+
 
 ######################
 # Double contraction #
@@ -59,7 +66,6 @@ Computes the norm of a tensor
 """
 Computes the outer product between two tensors `t1` and `t2`. Can also be called via the infix operator `⊗`.
 """
-@inline otimes{order, dim}(t1::AbstractTensor{order, dim}, t2::AbstractTensor{order, dim}) = otimes(promote(t1, t2)...)
 
 @generated function otimes{dim, T1, T2, M}(S1::Tensor{2, dim, T1, M}, S2::Tensor{2, dim, T2, M})
     N = n_components(Tensor{4, dim})
@@ -114,6 +120,7 @@ end
 
 @inline tdot{dim, T1, T2, M}(S1::SymmetricTensor{2, dim, T1, M}, S2::SymmetricTensor{2, dim, T2, M}) = dot(S1,S2)
 @inline tdot{dim, T1, T2, M1, M2}(S1::SymmetricTensor{2, dim, T1, M1}, S2::Tensor{2, dim, T2, M2}) = dot(S1,S2)
+@inline tdot{dim, T1, T2, M1, M2}(S1::Tensor{2, dim, T1, M1}, S2::SymmetricTensor{2, dim, T2, M2}) = tdot(promote(S1,S2)...)
 
 @inline function Base.dot{dim}(S1::SymmetricTensor{2, dim}, S2::SymmetricTensor{2, dim})
     S1_t = convert(Tensor{2, dim}, S1)
@@ -125,10 +132,7 @@ end
     return SymmetricTensor{2, dim}(transpdot(S1.data))
 end
 
-@inline tdot(S1::SymmetricTensor{2}) = dot(S1,S1)
-
-@inline Base.Ac_mul_B{dim}(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim}) = tdot(S1, S2)
-@inline Base.At_mul_B{dim}(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim}) = tdot(S1, S2)
+@inline tdot{dim}(S1::SymmetricTensor{2,dim}) = tdot(convert(Tensor{2,dim}, S1))
 
 # Promotion
 Base.dot{dim}(S1::Tensor{2, dim}, S2::SymmetricTensor{2, dim}) = dot(promote(S1, S2)...)

--- a/src/tensor_ops.jl
+++ b/src/tensor_ops.jl
@@ -1,3 +1,8 @@
+# Deprecate `*` for single/double contraction
+function Base.(:*)(S1::AbstractTensor, S2::AbstractTensor)
+    error("Don't use `*` for multiplication between tensors. Use `⋅` (`\\cdot`) for single contraction and `⊡` (`\\boxdot`) for double contraction.")
+end
+
 ######################
 # Double contraction #
 ######################
@@ -20,11 +25,6 @@ end
     Tv = typeof(zero(T1)*zero(T2))
     Tensor{2, dim, Tv, M}(Amt_mul_Bv(S2.data, S1.data))
 end
-
-@inline Base.(:*){dim}(S1::Tensor{4, dim}, S2::Tensor{2, dim}) = dcontract(S1, S2)
-@inline Base.(:*){dim}(S1::Tensor{2, dim}, S2::Tensor{4, dim}) = dcontract(S1, S2)
-@inline Base.(:*){dim}(S1::SymmetricTensor{4, dim}, S2::SymmetricTensor{2, dim}) = dcontract(S1, S2)
-@inline Base.(:*){dim}(S1::SymmetricTensor{2, dim}, S2::SymmetricTensor{4, dim}) = dcontract(S1, S2)
 
 const ⊡ = dcontract
 
@@ -101,9 +101,6 @@ end
     return Vec{dim, Tv}(Amt_mul_Bv(S2.data, v1.data))
 end
 
-@inline Base.(:*){dim}(S1::Tensor{1, dim}, S2::Tensor{2, dim}) = dot(S1, S2)
-@inline Base.(:*){dim}(S1::Tensor{2, dim}, S2::Tensor{1, dim}) = dot(S1, S2)
-
 
 @inline function Base.dot{dim, T1, T2, M}(S1::Tensor{2, dim, T1, M}, S2::Tensor{2, dim, T2, M})
     Tv = typeof(zero(T1) * zero(T2))
@@ -123,9 +120,6 @@ end
     S2_t = convert(Tensor{2, dim}, S2)
     return Tensor{2, dim}(Am_mul_Bm(S1_t.data, S2_t.data))
 end
-
-@inline Base.(:*){dim}(S1::Tensor{2, dim}, S2::Tensor{2, dim}) = dot(S1, S2)
-@inline Base.(:*){dim}(S1::SymmetricTensor{2, dim}, S2::SymmetricTensor{2, dim}) = dot(S1, S2)
 
 @inline function tdot{dim}(S1::Tensor{2, dim})
     return SymmetricTensor{2, dim}(transpdot(S1.data))

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+BaseTestNext

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,17 @@
 using ContMechTensors
-using Base.Test
+
+if VERSION >= v"0.5-"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 
 import ContMechTensors: n_independent_components, ArgumentError, get_data
 
 include("test_ops.jl")
 
+@testset "Constructors and simple math ops." begin
 for dim in (1,2,3)
     for order in (1,2,4)
         n_sym = n_independent_components(dim, true)
@@ -47,11 +54,13 @@ for dim in (1,2,3)
         end
     end
 end
+end # of testset
 
 
 ############
 # Indexing #
 ############
+@testset "Indexing" begin
 for dim in (1,2,3)
     for order in (1,2,4)
         n_sym = n_independent_components(dim, true)
@@ -89,8 +98,14 @@ for dim in (1,2,3)
         end
     end
 end
+end # of testset
 
 
+############################
+# Trace, norm, det and inv #
+############################
+
+@testset "trace, norm, det, inv" begin
 for dim in (1,2,3)
     for order in (2,4)
         t = rand(Tensor{order, dim})
@@ -99,6 +114,9 @@ for dim in (1,2,3)
         if order == 2
             @test (@inferred trace(t)) == sum([t[i,i] for i in 1:dim])
             @test (@inferred trace(t_sym)) == sum([t_sym[i,i] for i in 1:dim])
+
+            @test trace(t) ≈ vol(t) ≈ mean(t)*3.0
+            @test trace(t_sym) ≈ vol(t_sym) ≈ mean(t_sym)*3.0
 
             #@test_approx_eq_eps (mean(dev(t)) / norm(t)) 0.0 1e-14
             #@test_approx_eq_eps (mean(dev(t_sym)) / norm(t_sym)) 0.0 1e-14
@@ -135,12 +153,15 @@ for dim in (1,2,3)
    end
 end
 
+end # of testset
+
 
 ##############
 # Identities #
 ##############
 
 # https://en.wikiversity.org/wiki/Continuum_mechanics/Tensor_algebra_identities
+@testset "Tensor identities" begin
 for dim in (1,2,3)
     # Identities with second order and first order
     A = rand(Tensor{2, dim})
@@ -150,7 +171,7 @@ for dim in (1,2,3)
     a = rand(Tensor{1, dim, Float64})
     b = rand(Tensor{1, dim, Float64})
 
-    @test A ⊡ B ≈ (A' * B) ⊡ one(A)
+    @test A ⊡ B ≈ (A' ⋅ B) ⊡ one(A)
     @test A ⊡ (a ⊗ b) ≈ (A ⋅ b) ⋅ a
     @test (A ⋅ a) ⋅ (B ⋅ b) ≈ (A.' ⋅ B) ⊡ (a ⊗ b)
     @test (A ⋅ a) ⊗ b ≈ A ⋅ (a ⊗ b)
@@ -197,14 +218,15 @@ for dim in (1,2,3)
 
     #@test II_sym ⊡ A_sym ≈ A_sym
     #@test A_sym ⊡ II_sym ≈ A_sym
-
 end
+
+end # of testset
 
 
 ########################
 # Promotion/Conversion #
 ########################
-
+@testset "promotion/conversion" begin
 const T = Float32
 const WIDE_T = widen(T)
 for dim in (1,2,3)
@@ -242,3 +264,5 @@ for dim in (1,2,3)
         end
     end
 end
+
+end  # of testset

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -1,10 +1,5 @@
-# Test dcontract
-using ContMechTensors
-using Base.Test
-
-# Dcontract
+@testset "Tensor operations" begin
 for dim in (1,2,3)
-    println(dim)
     AA = rand(Tensor{4, dim})
     BB = rand(Tensor{4, dim})
     A = rand(Tensor{2, dim})
@@ -19,64 +14,126 @@ for dim in (1,2,3)
 
 
     #############
-    # Dcontract #
+    # dcontract #
     #############
 
     # 4 - 4
-     @test vec(dcontract(AA, BB)) ≈ vec(reshape(vec(AA), (dim^2, dim^2)) * reshape(vec(BB), (dim^2, dim^2)))
-     @test vec(dcontract(AA_sym, BB_sym)) ≈ vec(reshape(vec(AA_sym), (dim^2, dim^2)) * reshape(vec(BB_sym), (dim^2, dim^2)))
-     @test dcontract(convert(Tensor, AA_sym), convert(Tensor, BB_sym)) ≈ dcontract(AA_sym, BB_sym)
-     @test vec(dcontract(AA_sym, BB)) ≈ vec(reshape(vec(AA_sym), (dim^2, dim^2)) * reshape(vec(BB), (dim^2, dim^2)))
-     @test vec(dcontract(AA, BB_sym)) ≈ vec(reshape(vec(AA), (dim^2, dim^2)) * reshape(vec(BB_sym), (dim^2, dim^2)))
+    # Value tests
+    @test vec(dcontract(AA, BB)) ≈ vec(reshape(vec(AA), (dim^2, dim^2)) * reshape(vec(BB), (dim^2, dim^2)))
+    @test vec(dcontract(AA_sym, BB)) ≈ vec(reshape(vec(AA_sym), (dim^2, dim^2)) * reshape(vec(BB), (dim^2, dim^2)))
+    @test vec(dcontract(AA, BB_sym)) ≈ vec(reshape(vec(AA), (dim^2, dim^2)) * reshape(vec(BB_sym), (dim^2, dim^2)))
+    @test vec(dcontract(AA_sym, BB_sym)) ≈ vec(reshape(vec(AA_sym), (dim^2, dim^2)) * reshape(vec(BB_sym), (dim^2, dim^2)))
+    @test dcontract(convert(Tensor, AA_sym), convert(Tensor, BB_sym)) ≈ dcontract(AA_sym, BB_sym)
 
-     # 2 - 4
-     @test dcontract(AA, A) ≈ reshape(reshape(vec(AA), (dim^2, dim^2)) * reshape(vec(A), (dim^2,)), dim, dim)
-     @test dcontract(A, AA) ≈ reshape(reshape(vec(AA), (dim^2, dim^2))' * reshape(vec(A), (dim^2,)), dim, dim)
-     @test dcontract(AA_sym, A_sym) ≈ reshape(reshape(vec(AA_sym), (dim^2, dim^2)) * reshape(vec(A_sym), (dim^2,)), dim, dim)
-     @test dcontract(A_sym, AA_sym) ≈ reshape(reshape(vec(AA_sym), (dim^2, dim^2))' * reshape(vec(A_sym), (dim^2,)), dim, dim)
-     @test dcontract(A, AA) ≈ reshape(reshape(vec(AA), (dim^2, dim^2))' * reshape(vec(A), (dim^2,)), dim, dim)
-     @test dcontract(A_sym, AA) ≈ reshape(reshape(vec(AA), (dim^2, dim^2))' * reshape(vec(A_sym), (dim^2,)), dim, dim)
-     @test dcontract(A, AA_sym) ≈ reshape(reshape(vec(AA_sym), (dim^2, dim^2))' * reshape(vec(A), (dim^2,)), dim, dim)
-     @test dcontract(convert(Tensor, AA_sym), convert(Tensor, A_sym)) ≈ dcontract(AA_sym, A_sym)
+    # Type tests
+    @test typeof(dcontract(AA, BB)) <: Tensor{4,dim}
+    @test typeof(dcontract(AA_sym, BB)) <: Tensor{4,dim}
+    @test typeof(dcontract(AA, BB_sym)) <: Tensor{4,dim}
+    @test typeof(dcontract(AA_sym, BB_sym)) <: SymmetricTensor{4,dim}
 
 
-     # 2 - 2
-     @test dcontract(A, B) ≈ sum(vec(A) .* vec(B))
-     @test dcontract(A_sym, B_sym) ≈ sum(vec(A_sym) .* vec(B_sym))
-     @test dcontract(A, B_sym) ≈ sum(vec(A) .* vec(B_sym))
-     @test dcontract(A_sym, B) ≈ sum(vec(A_sym) .* vec(B))
+    # 2 - 4
+    # Value tests
+    @test dcontract(AA, A) ≈ reshape(reshape(vec(AA), (dim^2, dim^2)) * reshape(vec(A), (dim^2,)), dim, dim)
+    @test dcontract(AA_sym, A) ≈ reshape(reshape(vec(AA_sym), (dim^2, dim^2)) * reshape(vec(A), (dim^2,)), dim, dim)
+    @test dcontract(AA, A_sym) ≈ reshape(reshape(vec(AA), (dim^2, dim^2)) * reshape(vec(A_sym), (dim^2,)), dim, dim)
+    @test dcontract(AA_sym, A_sym) ≈ reshape(reshape(vec(AA_sym), (dim^2, dim^2)) * reshape(vec(A_sym), (dim^2,)), dim, dim)
+    @test dcontract(A, AA) ≈ reshape(reshape(vec(AA), (dim^2, dim^2))' * reshape(vec(A), (dim^2,)), dim, dim)
+    @test dcontract(A_sym, AA) ≈ reshape(reshape(vec(AA), (dim^2, dim^2))' * reshape(vec(A_sym), (dim^2,)), dim, dim)
+    @test dcontract(A, AA_sym) ≈ reshape(reshape(vec(AA_sym), (dim^2, dim^2))' * reshape(vec(A), (dim^2,)), dim, dim)
+    @test dcontract(A_sym, AA_sym) ≈ reshape(reshape(vec(AA_sym), (dim^2, dim^2))' * reshape(vec(A_sym), (dim^2,)), dim, dim)
+    @test dcontract(convert(Tensor, AA_sym), convert(Tensor, A_sym)) ≈ dcontract(AA_sym, A_sym)
+
+    # Type tests
+    @test typeof(dcontract(AA, A)) <: Tensor{2,dim}
+    @test typeof(dcontract(AA_sym, A)) <: Tensor{2,dim}
+    @test typeof(dcontract(AA, A_sym)) <: Tensor{2,dim}
+    @test typeof(dcontract(AA_sym, A_sym)) <: SymmetricTensor{2,dim}
+    @test typeof(dcontract(A, AA)) <: Tensor{2,dim}
+    @test typeof(dcontract(A_sym, AA)) <: Tensor{2,dim}
+    @test typeof(dcontract(A, AA_sym)) <: Tensor{2,dim}
+    @test typeof(dcontract(A_sym, AA_sym)) <: SymmetricTensor{2,dim}
 
 
-     #################
-     # Outer product #
-     #################
+    # 2 - 2
+    # Value tests
+    @test dcontract(A, B) ≈ sum(vec(A) .* vec(B))
+    @test dcontract(A_sym, B) ≈ sum(vec(A_sym) .* vec(B))
+    @test dcontract(A, B_sym) ≈ sum(vec(A) .* vec(B_sym))
+    @test dcontract(A_sym, B_sym) ≈ sum(vec(A_sym) .* vec(B_sym))
 
-     @test otimes(a, b) ≈ extract_components(a) * extract_components(b)'
-     @test reshape(vec(otimes(A, B)), dim^2, dim^2) ≈ vec(A) * vec(B)'
-     @test reshape(vec(otimes(A_sym, B_sym)), dim^2, dim^2) ≈ vec(A_sym) * vec(B_sym)'
-     @test reshape(vec(otimes(A, B_sym)), dim^2, dim^2) ≈ vec(A) * vec(B_sym)'
-     @test reshape(vec(otimes(A_sym, B)), dim^2, dim^2) ≈ vec(A_sym) * vec(B)'
+    # Type tests
+    @test typeof(dcontract(A, B)) <: Real
+    @test typeof(dcontract(A_sym, B)) <: Real
+    @test typeof(dcontract(A, B_sym)) <: Real
+    @test typeof(dcontract(A_sym, B_sym)) <: Real
+
+
+    #################
+    # Outer product #
+    #################
+
+    # Value tests
+    @test otimes(a, b) ≈ extract_components(a) * extract_components(b)'
+    @test reshape(vec(otimes(A, B)), dim^2, dim^2) ≈ vec(A) * vec(B)'
+    @test reshape(vec(otimes(A_sym, B)), dim^2, dim^2) ≈ vec(A_sym) * vec(B)'
+    @test reshape(vec(otimes(A, B_sym)), dim^2, dim^2) ≈ vec(A) * vec(B_sym)'
+    @test reshape(vec(otimes(A_sym, B_sym)), dim^2, dim^2) ≈ vec(A_sym) * vec(B_sym)'
+
+    # Type tests
+    @test typeof(otimes(a, b)) <: Tensor{2,dim}
+    @test typeof(otimes(A, B)) <: Tensor{4,dim}
+    @test typeof(otimes(A_sym, B)) <: Tensor{4,dim}
+    @test typeof(otimes(A, B_sym)) <: Tensor{4,dim}
+    @test typeof(otimes(A_sym, B_sym)) <: SymmetricTensor{4,dim}
+
 
     ################
     # Dot products #
     ################
 
     # 1 - 2
+    # Value tests
     @test dot(a, b) ≈ sum(extract_components(a) .* extract_components(b))
     @test dot(A, b) ≈ reshape(vec(A), (dim,dim)) * extract_components(b)
-    @test dot(b, A) ≈ reshape(vec(A), (dim,dim))' * extract_components(b)
     @test dot(A_sym, b) ≈ reshape(vec(A_sym), (dim,dim)) * extract_components(b)
-    @test dot(b, A_sym) ≈ reshape(vec(A_sym), (dim,dim))' * extract_components(b)
+    @test dot(a, B) ≈ reshape(vec(B), (dim,dim))' * extract_components(a)
+    @test dot(a, B_sym) ≈ reshape(vec(B_sym), (dim,dim))' * extract_components(a)
+
+    # Type tests
+    @test typeof(dot(a, b)) <: Real
+    @test typeof(dot(A, b)) <: Tensor{1,dim}
+    @test typeof(dot(A_sym, b)) <: Tensor{1,dim}
+    @test typeof(dot(b, A)) <: Tensor{1,dim}
+    @test typeof(dot(b, A_sym)) <: Tensor{1,dim}
 
     # 2 - 2
+    # Value tests
     @test dot(A, B) ≈ reshape(vec(A), (dim,dim)) * reshape(vec(B), (dim,dim))
-    @test dot(A_sym, B_sym) ≈ reshape(vec(A_sym), (dim,dim)) * reshape(vec(B_sym), (dim,dim))
-    @test dot(A, B_sym) ≈ reshape(vec(A), (dim,dim)) * reshape(vec(B_sym), (dim,dim))
     @test dot(A_sym, B) ≈ reshape(vec(A_sym), (dim,dim)) * reshape(vec(B), (dim,dim))
+    @test dot(A, B_sym) ≈ reshape(vec(A), (dim,dim)) * reshape(vec(B_sym), (dim,dim))
+    @test dot(A_sym, B_sym) ≈ reshape(vec(A_sym), (dim,dim)) * reshape(vec(B_sym), (dim,dim))
+
+    @test tdot(A, B) ≈ reshape(vec(A), (dim,dim))' * reshape(vec(B), (dim,dim))
+    @test tdot(A_sym, B) ≈ reshape(vec(A_sym), (dim,dim))' * reshape(vec(B), (dim,dim))
+    @test tdot(A, B_sym) ≈ reshape(vec(A), (dim,dim))' * reshape(vec(B_sym), (dim,dim))
+    @test tdot(A_sym, B_sym) ≈ reshape(vec(A_sym), (dim,dim))' * reshape(vec(B_sym), (dim,dim))
     @test tdot(A) ≈ reshape(vec(A), (dim,dim))' * reshape(vec(A), (dim,dim))
     @test tdot(A_sym) ≈ reshape(vec(A_sym), (dim,dim))' * reshape(vec(A_sym), (dim,dim))
-    @test tdot(A_sym,B) ≈ reshape(vec(A_sym), (dim,dim))' * reshape(vec(B), (dim,dim))
-    @test tdot(A_sym,A_sym) ≈ reshape(vec(A_sym), (dim,dim))' * reshape(vec(A_sym), (dim,dim))
+
+    # Type tests
+    @test typeof(dot(A, B)) <: Tensor{2,dim}
+    @test typeof(dot(A_sym, B)) <: Tensor{2,dim}
+    @test typeof(dot(A, B_sym)) <: Tensor{2,dim}
+    @test typeof(dot(A_sym, B_sym)) <: Tensor{2,dim}
+
+    @test typeof(tdot(A, B)) <: Tensor{2,dim}
+    @test typeof(tdot(A_sym, B)) <: Tensor{2,dim}
+    @test typeof(tdot(A, B_sym)) <: Tensor{2,dim}
+    @test typeof(tdot(A_sym, B_sym)) <: Tensor{2,dim}
+    @test typeof(tdot(A)) <: SymmetricTensor{2,dim}
+    @test typeof(tdot(A_sym)) <: SymmetricTensor{2,dim}
+
 
     ###############
     # Determinant #
@@ -105,7 +162,6 @@ for dim in (1,2,3)
             @test Af[i,j] == fij(i, j)
             for k in 1:dim, l in 1:dim
                 @test AAf[i,j,k,l] == fijkl(i, j,k,l)
-
             end
         end
     end
@@ -117,8 +173,5 @@ for dim in (1,2,3)
         end
     end
 
-
-
 end
-
-
+end # of testset


### PR DESCRIPTION
WIP I guess, since I always think of stuff after I have committed!

Removed `*` for tensor multiplication which was what caused most of the bugs I talked about earlier.

For instance returned `Array` instead of `Tensor` with some combinations of `SymmetricTensor` and `Tensor`:

``` jl
julia> A = rand(Tensor{2,2}); B = rand(SymmetricTensor{2,2});

julia> A*B
2x2 Array{Float64,2}:
 0.417769  0.469019 
 0.167622  0.0259839

julia> B*A
2x2 Array{Float64,2}:
 0.302653  0.241291
 0.457815  0.1411
```

The problem was that `*` wasn't overloaded for the same arguments as `dot` in all cases. I added tests for this, but now that only `dot`/`⋅` is used they might be ambiguous. But they still serve the purpose to check the return type.

Also updated readme and some other stuff.
