### PR TITLE
More error definitions

### DIFF
--- a/src/ContMechTensors.jl
+++ b/src/ContMechTensors.jl
@@ -63,6 +63,7 @@ include("symmetric_tuple_linalg.jl")
 include("indexing.jl")
 include("promotion_conversion.jl")
 include("tensor_ops.jl")
+include("tensor_ops_errors.jl")
 include("symmetric_ops.jl")
 include("data_functions.jl")
 

--- a/src/tensor_ops.jl
+++ b/src/tensor_ops.jl
@@ -1,15 +1,3 @@
-# Stop `*` from working with tensors
-function Base.(:*)(S1::AbstractTensor, S2::AbstractTensor)
-    error("Don't use `*` for multiplication between tensors. Use `⋅` (`\\cdot`) for single contraction and `⊡` (`\\boxdot`) for double contraction.")
-end
-function Base.Ac_mul_B{dim}(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim})
-    error("Don't use `A'*B`, use `tdot(A,B)` (or `A'⋅B`) instead.")
-end
-function Base.At_mul_B{dim}(S1::SecondOrderTensor{dim}, S2::SecondOrderTensor{dim})
-    error("Don't use `A.'*B`, use `tdot(A,B)` (or `A.'⋅B`) instead.")
-end
-
-
 ######################
 # Double contraction #
 ######################

--- a/src/tensor_ops_errors.jl
+++ b/src/tensor_ops_errors.jl
@@ -1,0 +1,16 @@
+# Give error for use of `*` as infix operator between tensors
+
+# Remove `*` as infix operator between tensors
+function Base.(:*)(S1::AbstractTensor, S2::AbstractTensor)
+    error("Don't use `*` for multiplication between tensors. Use `⋅` (`\\cdot`) for single contraction and `⊡` (`\\boxdot`) for double contraction.")
+end
+
+# Remove `'*` as infix operator between tensors
+function Base.Ac_mul_B(S1::AbstractTensor, S2::AbstractTensor)
+    error("Don't use `A'*B`, use `tdot(A,B)` (or `A'⋅B`) instead.")
+end
+
+# Remove `.'*` as infix operator between tensors
+function Base.At_mul_B(S1::AbstractTensor, S2::AbstractTensor)
+    error("Don't use `A.'*B`, use `tdot(A,B)` (or `A.'⋅B`) instead.")
+end


### PR DESCRIPTION
WIP

Adds error for multiplication between `Tensor` and `Array`:

master:

``` jl
julia> A = rand(Tensor{2,3}); b = rand(3);

julia> A*b
3-element Array{Float64,1}:
 0.87643 
 0.510982
 1.16645
```

PR:

``` jl
julia> A*b
ERROR: Multiplication between ContMechTensors.Tensor{2,3,Float64,9} and Array{Float64,1} not defined.
```

But why doesn't it hinder some other combinations in `tensor_ops_errors.jl` in this PR?

``` jl
julia> A = rand(Tensor{2,3}); B = rand(Tensor{1,3});

julia> a = rand(3,3); b = rand(3);

julia> A*b # This now gives error

julia> a*B # Still works for some reason, should it not go to the function between Array and Tensor in this PR?

julia> @which a*B
*{T,S}(A::AbstractArray{T,2}, x::AbstractArray{S,1}) at linalg/matmul.jl:83

```

And also, all of the combinations of `Ac_mul_B` and `At_mul_B` still works, using `Base`.
