### PR TITLE
Added symmetric and skew for 2nd order tensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ julia> A ⊗ B
 
 For vectors (first order tensors): `norm`
 
-For second order tensors: `norm`, `trace` (`vol`), `det`, `inv`, `transpose`, `eig`, `mean` defined as `trace(s) / 3`, and `dev` defined as `s - mean(s) * I`.
+For second order tensors: `norm`, `trace` (`vol`), `det`, `inv`, `transpose`, `symmetric`, `skew`, `eig`, `mean` defined as `trace(s) / 3`, and `dev` defined as `s - mean(s) * I`.
 
 For fourth order tensors: `norm` and `trace`
 

--- a/src/ContMechTensors.jl
+++ b/src/ContMechTensors.jl
@@ -17,8 +17,8 @@ immutable InternalError <: Exception end
 
 export AbstractTensor, SymmetricTensor, Tensor, Vec, FourthOrderTensor, SecondOrderTensor
 
-export otimes, otimes_unsym, ⊗, ⊡, dcontract, dev, vol
-export extract_components, load_components!, symmetrize, symmetrize!
+export otimes, otimes_unsym, ⊗, ⊡, dcontract, dev, vol, symmetric, skew
+export extract_components, load_components!
 export setindex, store!, tdot
 
 

--- a/src/tensor_ops.jl
+++ b/src/tensor_ops.jl
@@ -261,13 +261,59 @@ Base.ctranspose(S::AllTensors) = transpose(S)
 ############################
 
 """
-Computes the symmetric part of a second order tensor, returns a `SymmetricTensor`
+Computes the symmetric part of a second order tensor, returns a `SymmetricTensor{2}`
 """
-@inline symmetric{dim,T}(S1::Tensor{2,dim,T}) = convert(SymmetricTensor{2,dim,T},S1)
-@inline symmetric(S1::SymmetricTensor{2}) = S1
+@generated function symmetric{dim, T}(t::Tensor{2, dim, T})
+    N = n_components(SymmetricTensor{2, dim})
+    rows = Int(div(sqrt(1 + 8*N), 2))
+    exps = Expr[]
+    for row in 1:rows, col in row:rows
+        if row == col
+            push!(exps, :(t.data[$(compute_index(Tensor{2, dim}, row, col))]))
+        else
+            I = compute_index(Tensor{2, dim}, row, col)
+            J = compute_index(Tensor{2, dim}, col, row)
+            push!(exps, :(0.5 * (t.data[$I] + t.data[$J])))
+        end
+    end
+    exp = Expr(:tuple, exps...)
+    return quote
+            $(Expr(:meta, :inline))
+            SymmetricTensor{2, dim, T, $N}($exp)
+        end
+end
 
 """
-Computes the skew-symmetric (anti-symmetric) part of a second order tensor, returns a `Tensor`
+Computes the (minor) symmetric part of a fourth order tensor, returns a `SymmetricTensor{4}`
+"""
+@generated function symmetric{dim, T}(t::Tensor{4, dim, T})
+    N = n_components(Tensor{4, dim})
+    M = n_components(SymmetricTensor{4,dim})
+    rows = Int(N^(1/4))
+    exps = Expr[]
+    for k in 1:rows, l in k:rows, i in 1:rows, j in i:rows
+        if i == j & k == l
+            push!(exps, :(t.data[$(compute_index(Tensor{4, dim}, i, j, k, l))]))
+        else
+            I = compute_index(Tensor{4, dim}, i, j, k, l)
+            J = compute_index(Tensor{4, dim}, j, i, k, l)
+            K = compute_index(Tensor{4, dim}, i, j, k, l)
+            L = compute_index(Tensor{4, dim}, i, j, l, k)
+            push!(exps, :(0.25 * (t.data[$I] + t.data[$J] + t.data[$K] + t.data[$L])))
+        end
+    end
+    exp = Expr(:tuple, exps...)
+    return quote
+            $(Expr(:meta, :inline))
+            SymmetricTensor{4, dim, T, $M}($exp)
+        end
+end
+
+@inline symmetric(S1::SymmetricTensors) = S1
+
+
+"""
+Computes the skew-symmetric (anti-symmetric) part of a second order tensor, returns a `Tensor{2}`
 """
 @inline skew(S1::Tensor{2}) = 0.5*(S1 - S1.')
 @inline skew{dim,T}(S1::SymmetricTensor{2,dim,T}) = zero(Tensor{2,dim,T})

--- a/src/tensor_ops.jl
+++ b/src/tensor_ops.jl
@@ -256,6 +256,23 @@ end
 Base.ctranspose(S::AllTensors) = transpose(S)
 
 
+############################
+# Symmetric/Skew-symmetric #
+############################
+
+"""
+Computes the symmetric part of a second order tensor, returns a `SymmetricTensor`
+"""
+@inline symmetric{dim,T}(S1::Tensor{2,dim,T}) = convert(SymmetricTensor{2,dim,T},S1)
+@inline symmetric(S1::SymmetricTensor{2}) = S1
+
+"""
+Computes the skew-symmetric (anti-symmetric) part of a second order tensor, returns a `Tensor`
+"""
+@inline skew(S1::Tensor{2}) = 0.5*(S1 - S1.')
+@inline skew{dim,T}(S1::SymmetricTensor{2,dim,T}) = zero(Tensor{2,dim,T})
+
+
 #######
 # Eig #
 #######

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ else
     const Test = BaseTestNext
 end
 
-import ContMechTensors: n_independent_components, ArgumentError, get_data
+import ContMechTensors: n_independent_components, ArgumentError, get_data, isminorsymmetric, ismajorsymmetric
 
 include("test_ops.jl")
 
@@ -188,7 +188,6 @@ for dim in (1,2,3)
 
     @test A ⋅ a ≈ a ⋅ A'
 
-    @test convert(SymmetricTensor{2, dim}, A) ≈ 0.5(A + A')
 
 
     A_sym = rand(SymmetricTensor{2, dim})

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -145,9 +145,26 @@ for dim in (1,2,3)
     ############################
     # Symmetric/Skew-symmetric #
     ############################
+    if dim != 1
+        @test !issymmetric(A)
+        @test !issymmetric(AA)
+        @test !ismajorsymmetric(AA)
+        @test !isminorsymmetric(AA)
+        @test_throws InexactError convert(typeof(A_sym),A)
+        @test_throws InexactError convert(typeof(AA_sym),AA)
+    end
+    @test issymmetric(A_sym)
+    @test issymmetric(AA_sym)
+    @test isminorsymmetric(AA_sym)
+    @test issymmetric(symmetric(A))
+    @test issymmetric(A + A.')
+
     @test symmetric(A) ≈ 0.5(A + A.')
     @test symmetric(A_sym) ≈ A_sym
     @test typeof(symmetric(A)) <: SymmetricTensor{2,dim}
+    @test symmetric(AA_sym) ≈ AA_sym
+    @test typeof(symmetric(AA)) <: SymmetricTensor{4,dim}
+    @test convert(typeof(AA_sym),convert(Tensor,symmetric(AA))) ≈ symmetric(AA)
 
     @test skew(A) ≈ 0.5(A - A.')
     @test skew(A_sym) ≈ zero(A_sym)

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -142,6 +142,24 @@ for dim in (1,2,3)
     @test det(A) ≈ det(reshape(vec(A), (dim,dim)))
     @test det(A_sym) ≈ det(reshape(vec(A_sym), (dim,dim)))
 
+    ############################
+    # Symmetric/Skew-symmetric #
+    ############################
+    @test symmetric(A) ≈ 0.5(A + A.')
+    @test symmetric(A_sym) ≈ A_sym
+    @test typeof(symmetric(A)) <: SymmetricTensor{2,dim}
+
+    @test skew(A) ≈ 0.5(A - A.')
+    @test skew(A_sym) ≈ zero(A_sym)
+    @test typeof(skew(A_sym)) <: Tensor{2,dim}
+
+    # Identities
+    @test A ≈ symmetric(A) + skew(A)
+    @test skew(A) ≈ -skew(A).'
+    @test trace(skew(A)) ≈ 0.0
+    @test trace(symmetric(A)) ≈ trace(A)
+
+
     ##########################
     # Creating with function #
     ##########################


### PR DESCRIPTION
Added functions to take symmetric/skewsymmetric part with added tests. Not sure what I think about  `skw` as function name, but that's usually how it is written in literature. Better with `skew` ?

``` jl
julia> A = rand(Tensor{2,3})
3x3 ContMechTensors.Tensor{2,3,Float64,9}:
 0.250838  0.747916   0.852313
 0.332314  0.0192653  0.592624
 0.799777  0.661214   0.685426

julia> A_sym = sym(A)
3x3 ContMechTensors.SymmetricTensor{2,3,Float64,6}:
 0.250838  0.540115   0.826045
 0.540115  0.0192653  0.626919
 0.826045  0.626919   0.685426

julia> A_skw = skw(A)
3x3 ContMechTensors.Tensor{2,3,Float64,9}:
  0.0        0.207801    0.0262679
 -0.207801   0.0        -0.0342954
 -0.0262679  0.0342954   0.0 
```
