### PR TITLE
dotdot etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ For second order tensors: `norm`, `trace` (`vol`), `det`, `inv`, `transpose`, `s
 
 For fourth order tensors: `norm`, `trace`, `symmetric` (same as `minorsymmetric`), `majorsymmetric`, `transpose` (same as `minortranspose`), `majortranspose`, `permute_index`
 
-There is also a special function for computing `F' ⋅ F` between two general second order tensors which is called `tdot` and returns a `SymmetricTensor`.
+There is also a few special functions that can be convenient:
+
+* For computing `F' ⋅ F` between two general second order tensors there is `tdot(F)` which returns a `SymmetricTensor`.
+
+* For computing `a ⋅ C ⋅ b` for two vectors `a` and `b` and a fourth order tensors `C` there is `dotdot(a, C, b)`.
 
 ### Storing tensors in `type`s.
 

--- a/src/symmetric_ops.jl
+++ b/src/symmetric_ops.jl
@@ -218,3 +218,27 @@ function Base.eig{dim, T, M}(S::SymmetricTensor{2, dim, T, M})
     Φ = Tensor{2, dim}(ϕ)
     return Λ, Φ
 end
+
+###############################
+# Vec dot SecondOrder dot Vec #
+###############################
+
+@generated function dotdot{dim, T1, T2, T3}(v1::Vec{dim, T1}, S::SymmetricTensor{4, dim, T2}, v2::Vec{dim, T3})
+    idx(i,j,k,l) = compute_index(SymmetricTensor{4, dim}, i, j, k, l)
+    N = n_components(Tensor{2, dim})
+    Tv = typeof(one(T1) * one(T2) * one(T3))
+    exps = Expr(:tuple)
+    for j in 1:dim, i in 1:dim
+        exps_ele = Expr(:call)
+        push!(exps_ele.args, :+)
+        for l in 1:dim, k in 1:dim
+            push!(exps_ele.args, :(v1.data[$k] * S.data[$(idx(i,k,j,l))] * v2.data[$l]))
+        end
+        push!(exps.args, exps_ele)
+    end
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds r = $exps
+        Tensor{2, dim, $Tv, $N}(r)
+    end
+end

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -277,5 +277,12 @@ for dim in (1,2,3)
         end
     end
 
+    ###########
+    # Special #
+    ###########
+
+    AAT = Tensor{4, dim}((i,j,k,l) -> AA_sym[i,l,k,j])
+    @test AAT ⊡ (b ⊗ a) ≈ dotdot(a, AA_sym, b)
+
 end
 end # of testset


### PR DESCRIPTION
Adds dotdot which is exactly what you want when you compute `epsilon[Ni] * E * epsilon[Nj]` but now you have `dotdot(grad[Ni], E, grad[Nj])`.

Also cleans up some stuff, mostly in the constructors.
