### PR TITLE
Change deprecated syntax

### DIFF
--- a/src/tensor_ops_errors.jl
+++ b/src/tensor_ops_errors.jl
@@ -1,7 +1,7 @@
 # Give error for use of `*` as infix operator between tensors
 
 # Remove `*` as infix operator between tensors
-function Base.(:*)(S1::AbstractTensor, S2::AbstractTensor)
+@compat function Base.:*(S1::AbstractTensor, S2::AbstractTensor)
     error("Don't use `*` for multiplication between tensors. Use `⋅` (`\\cdot`) for single contraction and `⊡` (`\\boxdot`) for double contraction.")
 end
 


### PR DESCRIPTION
Realized now that this wont work on 0.4 so tests will break. Merge when 0.5 is released and scrap 0.4 support since it is slow on 0.4 anyway?
