### PR TITLE
dotdot

### DIFF
--- a/src/special_ops.jl
+++ b/src/special_ops.jl
@@ -7,16 +7,15 @@ such that ``a_k C_{ikjl} b_l``.
 dotdot(::Vec, ::SymmetricFourthOrderTensor, ::Vec)
 ```
 """
-@generated function dotdot{dim, T1, T2, T3}(v1::Vec{dim, T1}, S::SymmetricTensor{4, dim, T2}, v2::Vec{dim, T3})
+@generated function dotdot{dim}(v1::Vec{dim}, S::SymmetricTensor{4, dim}, v2::Vec{dim})
     idx(i,j,k,l) = compute_index(SymmetricTensor{4, dim}, i, j, k, l)
     exps = Expr(:tuple)
     for j in 1:dim, i in 1:dim
-        exps_ele = Expr(:call)
-        push!(exps_ele.args, :+)
+        exps_ele = Expr[]
         for l in 1:dim, k in 1:dim
-            push!(exps_ele.args, :(get_data(v1)[$k] * get_data(S)[$(idx(i,k,j,l))] * get_data(v2)[$l]))
+            push!(exps_ele, :(get_data(v1)[$k] * get_data(S)[$(idx(i,k,j,l))] * get_data(v2)[$l]))
         end
-        push!(exps.args, exps_ele)
+        push!(exps.args, reduce((ex1, ex2) -> :(+($ex1, $ex2)), exps_ele))
     end
     return quote
         $(Expr(:meta, :inline))


### PR DESCRIPTION
master:

```jl
julia> using ContMechTensors, BenchmarkTools

 julia> v1 = rand(Vec{3}); S1 = rand(SymmetricTensor{4,3}); v2 = rand(Vec{3});

julia> @benchmark dotdot($v1, $S1, $v2)
BenchmarkTools.Trial: 
  memory estimate:  1008.00 bytes
  allocs estimate:  63
  --------------
  minimum time:     271.277 ns (0.00% GC)
  median time:      295.568 ns (0.00% GC)
  mean time:        335.355 ns (7.67% GC)
  maximum time:     3.201 μs (81.83% GC)
  --------------
  samples:          10000
  evals/sample:     303
  time tolerance:   5.00%
  memory tolerance: 1.00%
```

PR:
```jl
julia> using ContMechTensors, BenchmarkTools

 julia> v1 = rand(Vec{3}); S1 = rand(SymmetricTensor{4,3}); v2 = rand(Vec{3});

julia> @benchmark dotdot($v1, $S1, $v2)
BenchmarkTools.Trial: 
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     36.319 ns (0.00% GC)
  median time:      36.643 ns (0.00% GC)
  mean time:        38.238 ns (0.00% GC)
  maximum time:     96.963 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     990
  time tolerance:   5.00%
  memory tolerance: 1.00%

```
