### PR TITLE
fix one for fourth order tensors

### DIFF
--- a/docs/src/man/constructing_tensors.md
+++ b/docs/src/man/constructing_tensors.md
@@ -88,7 +88,16 @@ julia> rand(SymmetricTensor{2,3,Float32})
 
 ## Identity tensors
 
-An identity tensor is created using the function `one`, applied to the type of tensor that should be created:
+Identity tensors can be created for orders 2 and 4. The components of the second order identity tensor ``\mathbf{I}`` are defined as ``I_{ij} = \delta_{ij}``, where ``\delta_{ij}`` is the Kronecker delta. The fourth order identity tensor ``\mathsf{I}`` is the resulting tensor from taking the derivative of a second order tensor ``\mathbf{A}`` with itself:
+
+$\mathsf{I} = \frac{\partial \mathbf{A}}{\partial \mathbf{A}} \Leftrightarrow I_{ijkl} = \frac{\partial A_{ij}}{\partial A_{kl}} = \delta_{ik} \delta_{jl}$
+
+The symmetric fourth order tensor, ``\mathsf{I}^\text{sym}``, is the resulting tensor from taking the derivative of a symmetric second order tensor ``\mathbf{A}^\text{sym}`` with itself:
+
+$\mathsf{I}^\text{sym} = \frac{\partial \mathbf{A}^\text{sym}}{\partial \mathbf{A}^\text{sym}} \Leftrightarrow I^\text{sym}_{ijkl} = \frac{\partial A^\text{sym}_{ij}}{\partial A^\text{sym}_{kl}} = \frac{1}{2} (\delta_{ik} \delta_{jl} + \delta_{il} \delta_{jk})$
+
+
+Identity tensors are created using the function `one`, applied to the type of tensor that should be created:
 
 ```jldoctest
 julia> one(SymmetricTensor{2, 2})
@@ -96,8 +105,6 @@ julia> one(SymmetricTensor{2, 2})
  1.0  0.0
  0.0  1.0
 ```
-
-The identity tensor is only defined for tensors of order 2 and 4.
 
 ## From arrays / tuples
 
@@ -134,7 +141,7 @@ For symmetric tensors, the function is only called for the lower triangular part
 
 ## Diagonal tensors
 
-A diagonal tensor can be created by either giving a number or a vector that should appear on the diagonal:
+A diagonal second order tensor can be created by either giving a number or a vector that should appear on the diagonal:
 
 ```jldoctest
 julia> diagm(Tensor{2,2}, 2.0)

--- a/src/ContMechTensors.jl
+++ b/src/ContMechTensors.jl
@@ -195,47 +195,42 @@ end
 # diagm
 for TensorType in (SymmetricTensor, Tensor)
     @eval begin
-        @generated function Base.diagm{order, dim}(Tt::Type{$(TensorType){order, dim}}, v::Union{AbstractVector, Tuple})
-            if order == 2
-                f = (i,j) -> i == j ? :(v[$i]) : :($(zero(eltype(v))))
-            elseif order == 4
-                f = (i,j,k,l) -> i == k && j == l ? :(v[$i]) : :($(zero(eltype(v))))
-            else
-                throw(ArgumentError("diagm only defined for tensors of order 2 and 4"))
-            end
-            exp = tensor_create(get_type(Tt),f)
+        @generated function Base.diagm{dim}(Tt::Type{$(TensorType){2, dim}}, v::Union{AbstractVector, Tuple})
+            f = (i,j) -> i == j ? :(v[$i]) : :($(zero(eltype(v))))
+            exp = tensor_create(get_type(Tt), f)
             return quote
                 $(Expr(:meta, :inline))
                 @inbounds t = $exp
-                $($TensorType){order, dim}(t)
+                $($TensorType){2, dim}(t)
             end
         end
 
-        @generated function Base.diagm{order, dim, T}(Tt::Type{$(TensorType){order, dim}}, v::T)
+        @inline Base.diagm{dim, T}(Tt::Type{$(TensorType){2, dim}}, v::T) = v * one($(TensorType){2, dim, T})
+    end
+end
+
+# one (identity tensor)
+for TensorType in (SymmetricTensor, Tensor)
+    @eval begin
+        @inline Base.one{order, dim}(Tt::Type{$(TensorType){order, dim}}) = one($TensorType{order, dim, Float64})
+        @inline Base.one{order, dim, T, M}(Tt::Type{$(TensorType){order, dim, T, M}}) = one($TensorType{order, dim, T})
+        @inline Base.one{order, dim, T}(Tt::$TensorType{order, dim, T}) = one($TensorType{order, dim, T})
+
+        @generated function Base.one{order, dim, T}(Tt::Type{$(TensorType){order, dim, T}})
+            !(order in (2,4)) && throw(ArgumentError("`one` only defined for order 2 and 4"))
+            δ = (i,j) -> i == j ? :($(one(T))) : :($(zero(T)))
             if order == 2
-                f = (i,j) -> i == j ? :(v) : :($(zero(T)))
-            elseif order == 4
-                f = (i,j,k,l) -> i == k && j == l ? :(v) : :($(zero(T)))
-            else
-                throw(ArgumentError("diagm only defined for tensors of order 2 and 4"))
+                f = (i,j) -> δ(i,j)
+            elseif order == 4 && $TensorType == Tensor
+                f = (i,j,k,l) -> δ(i,k) * δ(j,l)
+            else # order == 4 && TensorType == SymmetricTensor
+                f = (i,j,k,l) -> (δ(i,k) * δ(j,l) + δ(i,l) * δ(j,k)) / 2
             end
-            exp = tensor_create(get_type(Tt),f)
+            exp = tensor_create(get_base(get_type(Tt)), f)
             return quote
                 $(Expr(:meta, :inline))
                 $($TensorType){order, dim}($exp)
             end
-        end
-    end
-end
-
-# one
-for TensorType in (SymmetricTensor, Tensor)
-    for order in (2,4)
-        @eval begin
-            @inline Base.one{dim}(Tt::Type{$(TensorType){$order, dim}}) = one($TensorType{$order, dim, Float64})
-            @inline Base.one{dim, T, M}(Tt::Type{$(TensorType){$order, dim, T, M}}) = one($TensorType{$order, dim, T})
-            @inline Base.one{dim, T}(Tt::Type{$(TensorType){$order, dim, T}}) = diagm($(TensorType){$order, dim}, one(T))
-            @inline Base.one{dim, T}(Tt::$TensorType{$order, dim, T}) = one($TensorType{$order, dim, T})
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,10 +66,6 @@ for T in (Float32, Float64), dim in (1,2,3)
     @test isa(diagm(Tensor{2, dim}, v), Tensor{2, dim, T})
     @test diagm(SymmetricTensor{2, dim}, v) == diagm(vv)
     @test isa(diagm(SymmetricTensor{2, dim}, v), SymmetricTensor{2, dim, T})
-    @test diagm(Tensor{4, dim}, T(1)) == one(Tensor{4, dim, T})
-    @test isa(diagm(Tensor{4, dim}, T(1)), Tensor{4, dim, T})
-    @test diagm(SymmetricTensor{4, dim}, T(1)) == one(SymmetricTensor{4, dim, T})
-    @test isa(diagm(SymmetricTensor{4, dim}, T(1)), SymmetricTensor{4, dim, T})
 
     # one
     @test one(Tensor{2, dim, T}) == diagm(Tensor{2, dim}, one(T)) == eye(T, dim, dim)
@@ -94,10 +90,18 @@ for T in (Float32, Float64), dim in (1,2,3)
         for k in 1:dim, l in 1:dim
             if i == k && j == l
                 @test II[i,j,k,l] == T(1)
-                # @test II_sym[i,j,k,l] == T(1)
+                if i == l && j == k
+                    @test II_sym[i,j,k,l] == T(1)
+                else
+                    @test II_sym[i,j,k,l] == T(1) / 2
+                end
             else
                 @test II[i,j,k,l] == T(0)
-                # @test II_sym[i,j,k,l] == T(0)
+                if i == l && j == k
+                    @test II_sym[i,j,k,l] == T(1) / 2
+                else
+                    @test II_sym[i,j,k,l] == T(0)
+                end
             end
         end
     end
@@ -371,20 +375,33 @@ end
 
 for T in (Float32, Float64)
     for dim in (1,2,3)
-        # Identities with second order and first order
+        # Identities with identity tensor
         II = one(Tensor{4, dim, T})
         I = one(Tensor{2, dim, T})
+        AA = rand(Tensor{4, dim, T})
         A = rand(Tensor{2, dim, T})
-        #II_sym = one(SymmetricTensor{4, dim})
-        #A_sym = rand(SymmetricTensor{2, dim})
-        #I_sym = one(SymmetricTensor{2, dim})
+        II_sym = one(SymmetricTensor{4, dim, T})
+        I_sym = one(SymmetricTensor{2, dim, T})
+        AA_sym = rand(SymmetricTensor{4, dim, T})
+        A_sym = rand(SymmetricTensor{2, dim, T})
 
+        @test II ⊡ AA ≈ AA
+        @test AA ⊡ II ≈ AA
         @test II ⊡ A ≈ A
         @test A ⊡ II ≈ A
-        @test II ⊡ A ⊡ A ≈ (trace(A.' ⋅ A))
+        @test II ⊡ A ⊡ A ≈ (trace(A' ⋅ A))
 
-        #@test II_sym ⊡ A_sym ≈ A_sym
-        #@test A_sym ⊡ II_sym ≈ A_sym
+        @test II ⊡ AA_sym ≈ AA_sym
+        @test AA_sym ⊡ II ≈ AA_sym
+        @test II ⊡ A_sym ≈ A_sym
+        @test A_sym ⊡ II ≈ A_sym
+        @test II ⊡ A_sym ⊡ A_sym ≈ (trace(A_sym' ⋅ A_sym))
+
+        @test II_sym ⊡ AA_sym ≈ AA_sym
+        @test AA_sym ⊡ II_sym ≈ AA_sym
+        @test II_sym ⊡ A_sym ≈ A_sym
+        @test A_sym ⊡ II_sym ≈ A_sym
+        @test II_sym ⊡ A_sym ⊡ A_sym ≈ (trace(A_sym' ⋅ A_sym))
     end
 end
 end # of testset


### PR DESCRIPTION
Fix #79 

Also removed `diagm` for fourth order tensors, since it is not that clear what the diagonal is.