### PR TITLE
put signature first in docstrings

### DIFF
--- a/src/automatic_differentiation.jl
+++ b/src/automatic_differentiation.jl
@@ -288,13 +288,12 @@ end
 end
 
 """
-Computes the gradient of the input function. If the (pseudo)-keyword `all`
-is given, the value of the function is also returned as a second output argument
-
 ```julia
 gradient(f::Function, v::Union{SecondOrderTensor, Vec})
 gradient(f::Function, v::Union{SecondOrderTensor, Vec}, :all)
 ```
+Computes the gradient of the input function. If the (pseudo)-keyword `all`
+is given, the value of the function is also returned as a second output argument.
 
 **Example:**
 
@@ -321,14 +320,13 @@ function Base.gradient{F}(f::F, v::Union{SecondOrderTensor, Vec}, ::Symbol)
 end
 
 """
-Computes the hessian of the input function. If the (pseudo)-keyword `all`
-is given, the lower order results (gradient and value) of the function is
-also returned as a second and third output argument.
-
 ```julia
 hessian(f::Function, v::Union{SecondOrderTensor, Vec})
 hessian(f::Function, v::Union{SecondOrderTensor, Vec}, :all)
 ```
+Computes the hessian of the input function. If the (pseudo)-keyword `all`
+is given, the lower order results (gradient and value) of the function is
+also returned as a second and third output argument.
 
 **Example:**
 

--- a/src/math_ops.jl
+++ b/src/math_ops.jl
@@ -1,12 +1,11 @@
 # norm, det, inv, eig, trace, dev
 """
-Computes the norm of a tensor
-
 ```julia
 norm(::Vec)
 norm(::SecondOrderTensor)
 norm(::FourthOrderTensor)
 ```
+Computes the norm of a tensor.
 
 **Example:**
 
@@ -46,11 +45,10 @@ julia> norm(A)
 end
 
 """
-Computes the determinant of a second order tensor.
-
 ```julia
 det(::SecondOrderTensor)
 ```
+Computes the determinant of a second order tensor.
 
 **Example:**
 
@@ -90,11 +88,10 @@ julia> det(A)
 end
 
 """
-Computes the inverse of a second order tensor.
-
 ```julia
 inv(::SecondOrderTensor)
 ```
+Computes the inverse of a second order tensor.
 
 **Example:**
 
@@ -178,11 +175,10 @@ end
 end
 
 """
-Computes the eigenvalues and eigenvectors of a symmetric second order tensor.
-
 ```julia
 eig(::SymmetricSecondOrderTensor)
 ```
+Computes the eigenvalues and eigenvectors of a symmetric second order tensor.
 
 **Example:**
 
@@ -223,12 +219,11 @@ function Base.eig{dim, T, M}(S::SymmetricTensor{2, dim, T, M})
 end
 
 """
-Computes the trace of a second order tensor.
-The synonym `vol` can also be used.
-
 ```julia
 trace(::SecondOrderTensor)
 ```
+Computes the trace of a second order tensor.
+The synonym `vol` can also be used.
 
 **Example:**
 
@@ -253,11 +248,10 @@ vol(S::SecondOrderTensor) = trace(S)
 Base.mean(S::SecondOrderTensor) = trace(S) / 3
 
 """
-Computes the deviatoric part of a second order tensor.
-
 ```julia
 dev(::SecondOrderTensor)
 ```
+Computes the deviatoric part of a second order tensor.
 
 **Example:**
 

--- a/src/special_ops.jl
+++ b/src/special_ops.jl
@@ -1,11 +1,10 @@
 # specialized methods
 """
-Computes a special dot product between two vectors and a symmetric fourth order tensor
-such that ``a_k C_{ikjl} b_l``.
-
 ```julia
 dotdot(::Vec, ::SymmetricFourthOrderTensor, ::Vec)
 ```
+Computes a special dot product between two vectors and a symmetric fourth order tensor
+such that ``a_k C_{ikjl} b_l``.
 """
 @generated function dotdot{dim}(v1::Vec{dim}, S::SymmetricTensor{4, dim}, v2::Vec{dim})
     idx(i,j,k,l) = compute_index(SymmetricTensor{4, dim}, i, j, k, l)

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -1,13 +1,12 @@
 # symmetric, skew-symmetric and symmetric checks
 """
-Computes the symmetric part of a second or fourth order tensor.
-For a fourth order tensor, the symmetric part is the same as the minor symmetric part.
-Returns a `SymmetricTensor`.
-
 ```julia
 symmetric(::SecondOrderTensor)
 symmetric(::FourthOrderTensor)
 ```
+Computes the symmetric part of a second or fourth order tensor.
+For a fourth order tensor, the symmetric part is the same as the minor symmetric part.
+Returns a `SymmetricTensor`.
 
 **Example:**
 
@@ -44,11 +43,10 @@ julia> symmetric(A)
 end
 
 """
-Computes the minor symmetric part of a fourth order tensor, returns a `SymmetricTensor{4}`
-
 ```julia
 minorsymmetric(::FourthOrderTensor)
 ```
+Computes the minor symmetric part of a fourth order tensor, returns a `SymmetricTensor{4}`.
 """
 @generated function minorsymmetric{dim}(t::Tensor{4, dim})
     exps = Expr[]
@@ -76,11 +74,10 @@ end
 @inline symmetric(t::Tensor{4}) = minorsymmetric(t)
 
 """
-Computes the major symmetric part of a fourth order tensor, returns a `Tensor{4}`
-
 ```julia
 majorsymmetric(::FourthOrderTensor)
 ```
+Computes the major symmetric part of a fourth order tensor, returns a `Tensor{4}`.
 """
 @generated function majorsymmetric{dim}(t::FourthOrderTensor{dim})
     exps = Expr[]
@@ -102,11 +99,10 @@ majorsymmetric(::FourthOrderTensor)
 end
 
 """
-Computes the skew-symmetric (anti-symmetric) part of a second order tensor, returns a `Tensor{2}`
-
 ```julia
 skew(::SecondOrderTensor)
 ```
+Computes the skew-symmetric (anti-symmetric) part of a second order tensor, returns a `Tensor{2}`.
 """
 @inline skew(S1::Tensor{2}) = (S1 - S1.') / 2
 @inline skew{dim,T}(S1::SymmetricTensor{2,dim,T}) = zero(Tensor{2,dim,T})

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -1,15 +1,14 @@
 # dcontract, dot, tdot, otimes, cross
 """
-Computes the double contraction between two tensors.
-The symbol `⊡`, written `\\boxdot`, is overloaded for double contraction.
-The reason `:` is not used is because it does not have the same precedence as multiplication.
-
 ```julia
 dcontract(::SecondOrderTensor, ::SecondOrderTensor)
 dcontract(::SecondOrderTensor, ::FourthOrderTensor)
 dcontract(::FourthOrderTensor, ::SecondOrderTensor)
 dcontract(::FourthOrderTensor, ::FourthOrderTensor)
 ```
+Computes the double contraction between two tensors.
+The symbol `⊡`, written `\\boxdot`, is overloaded for double contraction.
+The reason `:` is not used is because it does not have the same precedence as multiplication.
 
 **Example:**
 
@@ -181,13 +180,12 @@ end
 @inline dcontract{dim}(S1::SymmetricTensor{4, dim}, S2::Tensor{4, dim}) = dcontract(promote(S1, S2)...)
 
 """
-Computes the open product between two tensors.
-The symbol `⊗`, written `\\otimes`, is overloaded for tensor products.
-
 ```julia
 otimes(::Vec, ::Vec)
 otimes(::SecondOrderTensor, ::SecondOrderTensor)
 ```
+Computes the open product between two tensors.
+The symbol `⊗`, written `\\otimes`, is overloaded for tensor products.
 
 **Example:**
 
@@ -235,15 +233,14 @@ end
 @inline otimes{dim}(S1::Tensor{2, dim}, S2::SymmetricTensor{2, dim}) = otimes(promote(S1, S2)...)
 
 """
-Computes the dot product (single contraction) between two tensors.
-The symbol `⋅`, written `\\cdot`, is overloaded for single contraction.
-
 ```julia
 dot(::Vec, ::Vec)
 dot(::Vec, ::SecondOrderTensor)
 dot(::SecondOrderTensor, ::Vec)
 dot(::SecondOrderTensor, ::SecondOrderTensor)
 ```
+Computes the dot product (single contraction) between two tensors.
+The symbol `⋅`, written `\\cdot`, is overloaded for single contraction.
 
 **Example:**
 
@@ -298,14 +295,13 @@ Base.dot{dim}(S1::Tensor{2, dim}, S2::SymmetricTensor{2, dim}) = dot(promote(S1,
 Base.dot{dim}(S1::SymmetricTensor{2, dim}, S2::Tensor{2, dim}) = dot(promote(S1, S2)...)
 
 """
-Computes the transpose-dot product (single contraction) between two tensors.
-
 ```julia
 tdot(::Vec, ::Vec)
 tdot(::Vec, ::SecondOrderTensor)
 tdot(::SecondOrderTensor, ::Vec)
 tdot(::SecondOrderTensor, ::SecondOrderTensor)
 ```
+Computes the transpose-dot product (single contraction) between two tensors.
 
 **Example:**
 
@@ -344,12 +340,11 @@ end
 @inline tdot{dim, T1, T2, M1, M2}(S1::Tensor{2, dim, T1, M1}, S2::SymmetricTensor{2, dim, T2, M2}) = tdot(promote(S1,S2)...)
 
 """
-Computes the transpose-dot of a second order tensor with itself.
-Returns a `SymmetricTensor`
-
 ```julia
 tdot(::SecondOrderTensor)
 ```
+Computes the transpose-dot of a second order tensor with itself.
+Returns a `SymmetricTensor`.
 
 **Example:**
 
@@ -387,12 +382,11 @@ end
 @inline tdot{dim}(S1::SymmetricTensor{2,dim}) = tdot(convert(Tensor{2,dim}, S1))
 
 """
-Computes the cross product between two `Vec` vectors, returns a `Vec{3}`. For dimensions 1 and 2 the `Vec`'s
-are expanded to 3D first. The infix operator × (written `\\times`) can also be used
-
 ```julia
 cross(::Vec, ::Vec)
 ```
+Computes the cross product between two `Vec` vectors, returns a `Vec{3}`. For dimensions 1 and 2 the `Vec`'s
+are expanded to 3D first. The infix operator × (written `\\times`) can also be used.
 
 **Example:**
 

--- a/src/transpose.jl
+++ b/src/transpose.jl
@@ -1,13 +1,12 @@
 # transpose, majortranspose, minortranspose
 """
-Computes the transpose of a tensor.
-For a fourth order tensor, the transpose is the minor transpose
-
 ```julia
 transpose(::Vec)
 transpose(::SecondOrderTensor)
 transpose(::FourthOrderTensor)
 ```
+Computes the transpose of a tensor.
+For a fourth order tensor, the transpose is the minor transpose.
 
 **Example:**
 
@@ -31,11 +30,10 @@ end
 Base.transpose(S::SymmetricTensor{2}) = S
 
 """
-Computes the minor transpose of a fourth order tensor.
-
 ```julia
 minortranspose(::FourthOrderTensor)
 ```
+Computes the minor transpose of a fourth order tensor.
 """
 @generated function minortranspose{dim}(t::Tensor{4, dim})
     exps = Expr[]
@@ -53,11 +51,10 @@ minortranspose(S::SymmetricTensor{4}) = S
 Base.transpose(S::FourthOrderTensor) = minortranspose(S)
 
 """
-Computes the major transpose of a fourth order tensor.
-
 ```julia
 majortranspose(::FourthOrderTensor)
 ```
+Computes the major transpose of a fourth order tensor.
 """
 @generated function majortranspose{dim}(t::FourthOrderTensor{dim})
     exps = Expr[]


### PR DESCRIPTION
Better to have it in this order, to go along the rest of Julia.

Master:
```jl
help?> dot
search: dot dotdot tdot vecdot STDOUT dcontract @doc_str TypedSlot midpoints fieldoffset fieldoffsets SecondOrderTensor UDPSocket field_offset

  dot(x, y)
  ⋅(x,y)

  Compute the dot product. For complex vectors, the first vector is conjugated.

  dot(n, X, incx, Y, incy)

  Dot product of two vectors consisting of n elements of array X with stride incx and n elements of array Y with stride incy.

  Computes the dot product (single contraction) between two tensors. The symbol ⋅, written \cdot, is overloaded for single contraction.

  dot(::Vec, ::Vec)
  dot(::Vec, ::SecondOrderTensor)
  dot(::SecondOrderTensor, ::Vec)
  dot(::SecondOrderTensor, ::SecondOrderTensor)

  Example:

  julia> A = rand(Tensor{2, 2})
  2×2 ContMechTensors.Tensor{2,2,Float64,4}:
   0.590845  0.566237
   0.766797  0.460085
```

PR:

```jl
help?> dot
search: dot dotdot tdot vecdot STDOUT dcontract @doc_str TypedSlot midpoints fieldoffset fieldoffsets SecondOrderTensor UDPSocket field_offset

  dot(x, y)
  ⋅(x,y)

  Compute the dot product. For complex vectors, the first vector is conjugated.

  dot(n, X, incx, Y, incy)

  Dot product of two vectors consisting of n elements of array X with stride incx and n elements of array Y with stride incy.

  dot(::Vec, ::Vec)
  dot(::Vec, ::SecondOrderTensor)
  dot(::SecondOrderTensor, ::Vec)
  dot(::SecondOrderTensor, ::SecondOrderTensor)

  Computes the dot product (single contraction) between two tensors. The symbol ⋅, written \cdot, is overloaded for single contraction.

  Example:

  julia> A = rand(Tensor{2, 2})
  2×2 ContMechTensors.Tensor{2,2,Float64,4}:
   0.590845  0.566237
   0.766797  0.460085

```
