### PR TITLE
add dott, remote tdot as binary op

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 
 julia:
   - 0.5
-  - nightly
+  # - nightly
 
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ environment:
   matrix:
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  # - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  # - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/docs/src/man/other_operators.md
+++ b/docs/src/man/other_operators.md
@@ -12,12 +12,15 @@ Pages = ["other_operators.md"]
 ```
 
 ## Transpose-dot
-The product between the transpose of a tensor with a second tensor.
+The dot product between the transpose of a tensor with itself. Results in a symmetric tensor.
 
-$\mathbf{A} = \mathbf{B}^\text{T} \cdot \mathbf{C} \Leftrightarrow A_{ij} = B_{ki}^\text{T} C_{kj} = B_{ik} C_{kj}$
+$\mathbf{A} = \mathbf{B}^\text{T} \cdot \mathbf{B} \Leftrightarrow A_{ij} = B_{ki}^\text{T} B_{kj} = B_{ik} B_{kj}$
+
+$\mathbf{A} = \mathbf{B} \cdot \mathbf{B}^\text{T} \Leftrightarrow A_{ij} = B_{ik} B_{jk}^\text{T} = B_{ik} B_{kj}$
 
 ```@docs
 tdot
+dott
 ```
 
 ## Norm

--- a/src/ContMechTensors.jl
+++ b/src/ContMechTensors.jl
@@ -9,7 +9,7 @@ export AbstractTensor, SymmetricTensor, Tensor, Vec, FourthOrderTensor, SecondOr
 
 export otimes, ⊗, ⊡, dcontract, dev, vol, symmetric, skew, minorsymmetric, majorsymmetric
 export minortranspose, majortranspose, isminorsymmetric, ismajorsymmetric
-export tdot, dotdot
+export tdot, dott, dotdot
 export hessian#, gradient
 
 @deprecate extract_components(tensor) Array(tensor)

--- a/src/tensor_products.jl
+++ b/src/tensor_products.jl
@@ -296,51 +296,6 @@ Base.dot{dim}(S1::SymmetricTensor{2, dim}, S2::Tensor{2, dim}) = dot(promote(S1,
 
 """
 ```julia
-tdot(::Vec, ::Vec)
-tdot(::Vec, ::SecondOrderTensor)
-tdot(::SecondOrderTensor, ::Vec)
-tdot(::SecondOrderTensor, ::SecondOrderTensor)
-```
-Computes the transpose-dot product (single contraction) between two tensors.
-
-**Example:**
-
-```jldoctest
-julia> A = rand(Tensor{2,2})
-2×2 ContMechTensors.Tensor{2,2,Float64,4}:
- 0.590845  0.566237
- 0.766797  0.460085
-
-julia> B = rand(Tensor{2,2})
-2×2 ContMechTensors.Tensor{2,2,Float64,4}:
- 0.794026  0.200586
- 0.854147  0.298614
-
-julia> tdot(A,B)
-2×2 ContMechTensors.Tensor{2,2,Float64,4}:
- 1.1241    0.347492
- 0.842587  0.250967
-
-julia> A'⋅B
-2×2 ContMechTensors.Tensor{2,2,Float64,4}:
- 1.1241    0.347492
- 0.842587  0.250967
-```
-"""
-@inline tdot{dim, T1, T2}(v1::Vec{dim, T1}, S2::SecondOrderTensor{dim, T2}) = dot(v1, S2)
-@inline tdot{dim, T1, T2}(S1::SecondOrderTensor{dim, T1}, v2::Vec{dim, T2}) = dot(v2, S1)
-@inline tdot{dim, T1, T2}(v1::Vec{dim, T1}, v2::Vec{dim, T2}) = dot(v1, v2)
-
-@inline function tdot{dim, T1, T2, M}(S1::Tensor{2, dim, T1, M}, S2::Tensor{2, dim, T2, M})
-    return Tensor{2, dim}(tomatrix(S1)' * tomatrix(S2))
-end
-
-@inline tdot{dim, T1, T2, M}(S1::SymmetricTensor{2, dim, T1, M}, S2::SymmetricTensor{2, dim, T2, M}) = dot(S1,S2)
-@inline tdot{dim, T1, T2, M1, M2}(S1::SymmetricTensor{2, dim, T1, M1}, S2::Tensor{2, dim, T2, M2}) = dot(S1,S2)
-@inline tdot{dim, T1, T2, M1, M2}(S1::Tensor{2, dim, T1, M1}, S2::SymmetricTensor{2, dim, T2, M2}) = tdot(promote(S1,S2)...)
-
-"""
-```julia
 tdot(::SecondOrderTensor)
 ```
 Computes the transpose-dot of a second order tensor with itself.
@@ -383,10 +338,35 @@ end
 
 """
 ```julia
+dott(::SecondOrderTensor)
+```
+Computes the dot-transpose of a second order tensor with itself.
+Returns a `SymmetricTensor`.
+
+**Example:**
+
+```jldoctest
+julia> A = rand(Tensor{2,3})
+3×3 ContMechTensors.Tensor{2,3,Float64,9}:
+ 0.590845  0.460085  0.200586
+ 0.766797  0.794026  0.298614
+ 0.566237  0.854147  0.246837
+
+julia> dott(A)
+3×3 ContMechTensors.SymmetricTensor{2,3,Float64,6}:
+ 0.601011  0.878275  0.777051
+ 0.878275  1.30763   1.18611
+ 0.777051  1.18611   1.11112
+```
+"""
+@inline dott(S::SecondOrderTensor) = tdot(transpose(S))
+
+"""
+```julia
 cross(::Vec, ::Vec)
 ```
 Computes the cross product between two `Vec` vectors, returns a `Vec{3}`. For dimensions 1 and 2 the `Vec`'s
-are expanded to 3D first. The infix operator × (written `\\times`) can also be used.
+are expanded to 3D first. The infix operator `×` (written `\\times`) can also be used.
 
 **Example:**
 

--- a/test/test_ops.jl
+++ b/test/test_ops.jl
@@ -94,24 +94,12 @@ end # of testset
     @test dot(a, B) ≈ Array(B)' * Array(a)
     @test dot(a, B_sym) ≈ Array(B_sym)' * Array(a)
 
-    @test tdot(a, b) ≈ tdot(b, a) ≈ dot(a,b) ≈ dot(b,a) ≈ sum(Array(a) .* Array(b))
-    @test tdot(A, b) ≈ tdot(b, A) ≈ dot(b,A) ≈ Array(A)' * Array(b)
-    @test tdot(A_sym, b) ≈ tdot(b, A_sym) ≈ dot(A_sym, b) ≈ Array(A_sym)' * Array(b)
-    @test tdot(a, B) ≈ tdot(B, a) ≈ dot(a, B) ≈ Array(B)' * Array(a)
-    @test tdot(a, B_sym) ≈ tdot(B_sym, a) ≈ dot(a, B_sym) ≈ Array(B_sym)' * Array(a)
-
     # Type tests
     @test isa(dot(a, b), T)
     @test isa(dot(A, b), Vec{dim, T})
     @test isa(dot(A_sym, b), Vec{dim, T})
     @test isa(dot(b, A), Vec{dim, T})
     @test isa(dot(b, A_sym), Vec{dim, T})
-
-    @test isa(tdot(a, b), T)
-    @test isa(tdot(A, b), Vec{dim, T})
-    @test isa(tdot(A_sym, b), Vec{dim, T})
-    @test isa(tdot(a, B), Vec{dim, T})
-    @test isa(tdot(a, B_sym), Vec{dim, T})
 
     # 2 - 2
     # Value tests
@@ -120,12 +108,14 @@ end # of testset
     @test dot(A, B_sym) ≈ Array(A) * Array(B_sym)
     @test dot(A_sym, B_sym) ≈ Array(A_sym) * Array(B_sym)
 
-    @test tdot(A, B) ≈ Array(A)' * Array(B)
-    @test tdot(A_sym, B) ≈ Array(A_sym)' * Array(B)
-    @test tdot(A, B_sym) ≈ Array(A)' * Array(B_sym)
-    @test tdot(A_sym, B_sym) ≈ Array(A_sym)' * Array(B_sym)
     @test tdot(A) ≈ Array(A)' * Array(A)
     @test tdot(A_sym) ≈ Array(A_sym)' * Array(A_sym)
+    @test dott(A) ≈ Array(A) * Array(A)'
+    @test dott(A_sym) ≈ Array(A_sym) * Array(A_sym)'
+    @test tdot(A) ≈ dott(transpose(A))
+    @test tdot(transpose(A)) ≈ dott(A)
+    @test tdot(A_sym) ≈ dott(transpose(A_sym))
+    @test tdot(transpose(A_sym)) ≈ dott(A_sym)
 
     # Type tests
     @test isa(dot(A, B), Tensor{2, dim, T})
@@ -133,12 +123,10 @@ end # of testset
     @test isa(dot(A, B_sym), Tensor{2, dim, T})
     @test isa(dot(A_sym, B_sym), Tensor{2, dim, T})
 
-    @test isa(tdot(A, B), Tensor{2, dim, T})
-    @test isa(tdot(A_sym, B), Tensor{2, dim, T})
-    @test isa(tdot(A, B_sym), Tensor{2, dim, T})
-    @test isa(tdot(A_sym, B_sym), Tensor{2, dim, T})
     @test isa(tdot(A), SymmetricTensor{2, dim, T})
     @test isa(tdot(A_sym), SymmetricTensor{2, dim, T})
+    @test isa(dott(A), SymmetricTensor{2, dim, T})
+    @test isa(dott(A_sym), SymmetricTensor{2, dim, T})
 end # of testset
 
 @testset "symmetric/skew-symmetric" begin


### PR DESCRIPTION
close #58 

Unless we perform less operations, it is not worth specializing methods since simple operations like transpose and convert are optimized away anyway.

This also removes the two argument `tdot`, since that didn't do anything really.