### PR TITLE
Type stable `zeros` and `ones`

### DIFF
--- a/src/ContMechTensors.jl
+++ b/src/ContMechTensors.jl
@@ -167,7 +167,7 @@ for op in (:+, :-, :.+, :.-, :.*, :./)
         end
     end
     @eval begin
-        Base.$op{order, dim}(t1::AbstractTensor{order, dim}, t2::AbstractTensor{order, dim}) = Base.$op(promote(t1, t2)...)
+        Base.$op{order, dim}(t1::AbstractTensor{order, dim}, t2::AbstractTensor{order, dim}) = $op(promote(t1, t2)...)
     end
 end
 
@@ -179,8 +179,8 @@ end
 for op in (:zero, :rand, :ones)
     for TensorType in (SymmetricTensor, Tensor)
         @eval begin
-            @inline Base.$op{order, dim}(Tt::Type{$TensorType{order, dim}}) = Base.$op($TensorType{order, dim, Float64})
-            @inline Base.$op{order, dim, T, M}(Tt::Type{$TensorType{order, dim, T, M}}) = Base.$op($TensorType{order, dim, T})
+            @inline Base.$op{order, dim}(Tt::Type{$TensorType{order, dim}}) = $op($TensorType{order, dim, Float64})
+            @inline Base.$op{order, dim, T, M}(Tt::Type{$TensorType{order, dim, T, M}}) = $op($TensorType{order, dim, T})
             @inline function Base.$op{order, dim, T}(Tt::Type{$TensorType{order, dim, T}})
                 N = n_components($TensorType{order, dim})
                 return $TensorType{order, dim}($op(SVector{N, T}))
@@ -188,7 +188,7 @@ for op in (:zero, :rand, :ones)
         end
     end
     # Special case for Vec
-    @eval @inline Base.$op{dim}(Tt::Type{Vec{dim}}) = Base.$op(Vec{dim, Float64})
+    @eval @inline Base.$op{dim}(Tt::Type{Vec{dim}}) = $op(Vec{dim, Float64})
 
     # zero, rand or ones of a tensor
     @eval @inline Base.$op(t::AllTensors) = $op(typeof(t))

--- a/src/ContMechTensors.jl
+++ b/src/ContMechTensors.jl
@@ -194,6 +194,20 @@ for op in (:zero, :rand, :ones)
     @eval @inline Base.$op(t::AllTensors) = $op(typeof(t))
 end
 
+# zeros
+for TensorType in (SymmetricTensor, Tensor)
+    @eval begin
+        @inline Base.zeros{order, dim}(Tt::Type{$TensorType{order, dim}}, dims...) = zeros($TensorType{order, dim, Float64}, dims...)
+        @inline function Base.zeros{order, dim, T}(Tt::Type{$TensorType{order, dim, T}}, dims...)
+            N = n_components($TensorType{order, dim})
+            return zeros($TensorType{order, dim, T, N}, dims...)
+        end
+        @inline Base.zeros{order, dim, T, M}(Tt::Type{$TensorType{order, dim, T, M}}, dims...) =
+            fill!(Array{$TensorType{order, dim, T, M}}(dims...), zero($TensorType{order, dim, T}))
+    end
+end
+@inline Base.zeros{dim}(::Type{Vec{dim}}, dims...) = zeros(Vec{dim, Float64}, dims...)
+
 # diagm
 for TensorType in (SymmetricTensor, Tensor)
     @eval begin

--- a/src/ContMechTensors.jl
+++ b/src/ContMechTensors.jl
@@ -194,19 +194,21 @@ for op in (:zero, :rand, :ones)
     @eval @inline Base.$op(t::AllTensors) = $op(typeof(t))
 end
 
-# zeros
-for TensorType in (SymmetricTensor, Tensor)
-    @eval begin
-        @inline Base.zeros{order, dim}(Tt::Type{$TensorType{order, dim}}, dims...) = zeros($TensorType{order, dim, Float64}, dims...)
-        @inline function Base.zeros{order, dim, T}(Tt::Type{$TensorType{order, dim, T}}, dims...)
-            N = n_components($TensorType{order, dim})
-            return zeros($TensorType{order, dim, T, N}, dims...)
+# zeros, ones
+for (op, el) in ((:zeros, :zero), (:ones, :one))
+    for TensorType in (SymmetricTensor, Tensor)
+        @eval begin
+            @inline Base.$op{order, dim}(Tt::Type{$TensorType{order, dim}}, dims...) = $op($TensorType{order, dim, Float64}, dims...)
+            @inline function Base.$op{order, dim, T}(Tt::Type{$TensorType{order, dim, T}}, dims...)
+                N = n_components($TensorType{order, dim})
+                return $op($TensorType{order, dim, T, N}, dims...)
+            end
+            @inline Base.$op{order, dim, T, M}(Tt::Type{$TensorType{order, dim, T, M}}, dims...) =
+                fill!(Array{$TensorType{order, dim, T, M}}(dims...), $el($TensorType{order, dim, T}))
         end
-        @inline Base.zeros{order, dim, T, M}(Tt::Type{$TensorType{order, dim, T, M}}, dims...) =
-            fill!(Array{$TensorType{order, dim, T, M}}(dims...), zero($TensorType{order, dim, T}))
     end
+    @eval @inline Base.$op{dim}(::Type{Vec{dim}}, dims...) = $op(Vec{dim, Float64}, dims...)
 end
-@inline Base.zeros{dim}(::Type{Vec{dim}}, dims...) = zeros(Vec{dim, Float64}, dims...)
 
 # diagm
 for TensorType in (SymmetricTensor, Tensor)


### PR DESCRIPTION
Implements `Base`s version of `zeros` and `ones`.

Master:
```jl
julia> zeros(Tensor{2,2}, 2,2)
2×2 Array{ContMechTensors.Tensor{2,2,T<:Real,M},2}:
 [0.0 0.0; 0.0 0.0]  [0.0 0.0; 0.0 0.0]
 [0.0 0.0; 0.0 0.0]  [0.0 0.0; 0.0 0.0]

julia> ones(Tensor{2,2}, 2,2)
2×2 Array{ContMechTensors.Tensor{2,2,T<:Real,M},2}:
 [1.0 0.0; 0.0 1.0]  [1.0 0.0; 0.0 1.0]
 [1.0 0.0; 0.0 1.0]  [1.0 0.0; 0.0 1.0]
```

PR:
```jl
julia> zeros(Tensor{2,2}, 2,2)
2×2 Array{ContMechTensors.Tensor{2,2,Float64,4},2}:
 [0.0 0.0; 0.0 0.0]  [0.0 0.0; 0.0 0.0]
 [0.0 0.0; 0.0 0.0]  [0.0 0.0; 0.0 0.0]

julia> ones(Tensor{2,2}, 2,2)
2×2 Array{ContMechTensors.Tensor{2,2,Float64,4},2}:
 [1.0 0.0; 0.0 1.0]  [1.0 0.0; 0.0 1.0]
 [1.0 0.0; 0.0 1.0]  [1.0 0.0; 0.0 1.0]
```