### PR TITLE
Use muladd

### DIFF
--- a/src/special_ops.jl
+++ b/src/special_ops.jl
@@ -10,11 +10,12 @@ such that ``a_k C_{ikjl} b_l``.
     idx(i,j,k,l) = compute_index(SymmetricTensor{4, dim}, i, j, k, l)
     exps = Expr(:tuple)
     for j in 1:dim, i in 1:dim
-        exps_ele = Expr[]
+        ex1, ex2 = Expr[],Expr[]
         for l in 1:dim, k in 1:dim
-            push!(exps_ele, :(get_data(v1)[$k] * get_data(S)[$(idx(i,k,j,l))] * get_data(v2)[$l]))
+            push!(ex1, :(get_data(v1)[$k] * get_data(S)[$(idx(i,k,j,l))]))
+            push!(ex2, :(get_data(v2)[$l]))
         end
-        push!(exps.args, reduce((ex1, ex2) -> :(+($ex1, $ex2)), exps_ele))
+        push!(exps.args, make_muladd_exp(ex1, ex2))
     end
     return quote
         $(Expr(:meta, :inline))

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -22,3 +22,23 @@ function tensor_create{order, dim}(::Type{SymmetricTensor{order, dim}}, f)
     end
     return ex
 end
+
+# create recursive muladd exp from two expression arrays
+function make_muladd_exp(ex1, ex2)
+    N = length(ex1)
+    ex = Expr(:call)
+    exn = Expr(:call, :*, ex1[1], ex2[1])
+
+    if N == 1 # return only the multiplication
+        return exn
+    end
+
+    for i in 2:N
+        ex = Expr(:call, :muladd)
+        push!(ex.args, ex1[i])
+        push!(ex.args, ex2[i])
+        push!(ex.args, exn)
+        exn = ex
+    end
+    return ex
+end


### PR DESCRIPTION
Use `muladd` instruction for the functions we define.

Benchmarking:
https://gist.github.com/fredrikekre/f305e00f15c8540c9a2b795a484b4923

with `-O3`:
https://gist.github.com/fredrikekre/9ab7e53e20f9713cb84ed572fb03b22a

If the type is something else than a float it will hit [this](https://github.com/JuliaLang/julia/blob/master/base/promotion.jl#L307) so it should be safe for the dual numbers (and other types).

PR:
```jl
julia> using ContMechTensors

julia> A = rand(SymmetricTensor{2, 2}); B = rand(typeof(A));

julia> @code_native dcontract(A, B)
	.text
Filename: tensor_products.jl
	pushq	%rbp
	movq	%rsp, %rbp
Source line: 59
	vmovsd	16(%rdi), %xmm1         # xmm1 = mem[0],zero
	vmovsd	8(%rsi), %xmm2          # xmm2 = mem[0],zero
	vmovsd	16(%rsi), %xmm0         # xmm0 = mem[0],zero
	vmovsd	(%rdi), %xmm3           # xmm3 = mem[0],zero
	vmovsd	8(%rdi), %xmm4          # xmm4 = mem[0],zero
	vaddsd	%xmm4, %xmm4, %xmm4
	vmulsd	(%rsi), %xmm3, %xmm3
	vfmadd213sd	%xmm3, %xmm2, %xmm4
	vfmadd213sd	%xmm4, %xmm1, %xmm0
Source line: 45
	popq	%rbp
	retq
```

master:
```jl
julia> using ContMechTensors

julia> A = rand(SymmetricTensor{2, 2}); B = rand(typeof(A));

julia> @code_native dcontract(A, B)
	.text
Filename: tensor_products.jl
	pushq	%rbp
	movq	%rsp, %rbp
Source line: 57
	vmovsd	(%rdi), %xmm0           # xmm0 = mem[0],zero
	vmovsd	8(%rdi), %xmm1          # xmm1 = mem[0],zero
	vmulsd	(%rsi), %xmm0, %xmm0
	vaddsd	%xmm1, %xmm1, %xmm1
	vmulsd	8(%rsi), %xmm1, %xmm1
	vaddsd	%xmm1, %xmm0, %xmm0
	vmovsd	16(%rdi), %xmm1         # xmm1 = mem[0],zero
	vmulsd	16(%rsi), %xmm1, %xmm1
	vaddsd	%xmm1, %xmm0, %xmm0
Source line: 45
	popq	%rbp
	retq
	nop
```
